### PR TITLE
libcoveoc4ids/config.py: Update for OC4IDS 0.9.4

### DIFF
--- a/libcoveoc4ids/config.py
+++ b/libcoveoc4ids/config.py
@@ -3,7 +3,7 @@ from libcove.config import LIB_COVE_CONFIG_DEFAULT, LibCoveConfig
 versions = {}
 
 # Available versions
-versions['0.9.3'] = ('0.9.3', 'http://standard.open-contracting.org/infrastructure/schema/0__9__3/')
+versions['0.9.4'] = ('0.9.4', 'http://standard.open-contracting.org/infrastructure/schema/0__9__4/')
 
 LIB_COVE_OC4IDS_CONFIG_DEFAULT = LIB_COVE_CONFIG_DEFAULT.copy()
 
@@ -15,10 +15,10 @@ LIB_COVE_OC4IDS_CONFIG_DEFAULT.update({
     'convert_titles': False,
     'schema_name': 'project-package-schema.json',
     'schema_item_name': 'project-schema.json',
-    'schema_version': '0.9.3',
+    'schema_version': '0.9.4',
     'schema_version_choices': versions,
     'schema_host':
-    'http://standard.open-contracting.org/infrastructure/schema/0__9__3/',
+    'http://standard.open-contracting.org/infrastructure/schema/0__9__4/',
     'schema_codelists': {
         "0.9": "https://raw.githubusercontent.com/open-contracting/infrastructure/0.9/schema/project-level/codelists/",
     },

--- a/tests/fixtures/example-data.json
+++ b/tests/fixtures/example-data.json
@@ -16,7 +16,7 @@
       "updated": "2018-12-10T15:53:00Z",
       "title": "M75 Junctions 4 to 5 upgrade smart motorway",
       "description": "Upgrading the 5km stretch of the M75 near Birmingham Airport, between junction 4 near Patcham and junction 5 at Windlesham, to an all-lane running smart motorway.",
-      "status": "completed",
+      "status": "maintenance",
       "period": {
         "startDate": "2016-01-01T00:00:00Z",
         "endDate": "2018-12-10T00:00:00Z",

--- a/tests/fixtures/validation-errors-package.json
+++ b/tests/fixtures/validation-errors-package.json
@@ -29,7 +29,7 @@
           "currency": "upmceageaqwjjg"
         },
         "approvalDate": "",
-        "budgetBreakdown": "xxrzeqvnbcxxrzeqvnbcxxrzeqvnbc"
+        "budgetBreakdowns": "xxrzeqvnbcxxrzeqvnbcxxrzeqvnbc"
       },
       "parties": 4,
       "documents": "xxrzeqvnbc",
@@ -215,7 +215,7 @@
         },
         "requestDate": "2015-05-30T00:00:00Z",
         "approvalDate": "2015-06-24T00:00:00Z",
-        "budgetBreakdown": [
+        "budgetBreakdowns": [
           {
             "id": "1",
             "description": "2016 budget allocation",


### PR DESCRIPTION
I think that tests will only pass after https://github.com/open-contracting/infrastructure/pull/465 is merged.